### PR TITLE
feat: update logic to support populate statements

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -1,0 +1,25 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x, 15.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - run: npm ci
+    - run: npm test

--- a/index.js
+++ b/index.js
@@ -47,15 +47,15 @@ const erm2openapi = (
     ...rest,
   };
 
-  return Object.entries(models).reduce((acc, curr) => {
-    const [key] = curr;
+  return Object.values(models).reduce((acc, curr) => {
+    const { model: { modelName } } = curr;
     const { paths, schemas } = getModelSegments(curr, options);
 
     return {
       ...acc,
       tags: [
         ...acc.tags,
-        { name: key, description: `REST interface for ${key} model` },
+        { name: modelName, description: `REST interface for ${modelName} model` },
       ],
       paths: {
         ...acc.paths,

--- a/index.test.js
+++ b/index.test.js
@@ -2,7 +2,7 @@ const mongoose = require('mongoose');
 const validator = require('oas-validator');
 const { createGraphQLSchema } = require("openapi-to-graphql");
 const erm2openapi = require('.');
-const document = require('./test/fixtures/api-docs.json')
+const document = require('./test/fixtures/api-docs.json');
 
 const personSchema = mongoose.Schema({
   name: { type: String, required: true },

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,14 @@
 const _ = require('lodash');
-const m2s = require('mongoose-to-swagger');
 const { getErrorResponses } = require('./errors');
 const { getQueryParameters, getPathParameters } = require('./parameters');
 const { getOperationId } = require('./operations');
+const { m2s } = require('./utils');
 
-const getModelSchemas = ([
-  key,
-  { model, options: { model: modelOptions } = {} },
-]) => {
+const getModelSchemas = ({ model, options: { model: modelOptions } = {} }) => {
+  const { modelName } = model;
   const { title, ...rest } = m2s(model, modelOptions);
   return {
-    [key]: {
+    [modelName]: {
       type: 'object',
       ...rest,
     },
@@ -18,25 +16,23 @@ const getModelSchemas = ([
 };
 
 const getModelPaths = (
-  [
-    key,
-    {
-      options: {
-        erm: { prefix = '/api', version = '/v1' } = {},
-        openapi: { paths: modelPathOverrides = {} } = {},
-      } = {},
+  {
+    model: { modelName },
+    options: {
+      erm: { prefix = '/api', version = '/v1' } = {},
+      openapi: { paths: modelPathOverrides = {} } = {},
     } = {},
-  ],
+  } = {},
   { openapi: { paths: globalPathOverrides = {} } = {} } = {},
 ) => {
-  const pathPrefix = `${prefix}${version}/${key}`;
+  const pathPrefix = `${prefix}${version}/${modelName}`;
 
   return {
     [pathPrefix]: {
       get: {
-        summary: `Query ${key}`,
-        operationId: getOperationId({ model: key }),
-        tags: [key],
+        summary: `Query ${modelName}`,
+        operationId: getOperationId({ model: modelName }),
+        tags: [modelName],
         parameters: getQueryParameters(),
         responses: {
           200: {
@@ -46,7 +42,7 @@ const getModelPaths = (
                 schema: {
                   type: 'array',
                   items: {
-                    $ref: `#/components/schemas/${key}`,
+                    $ref: `#/components/schemas/${modelName}`,
                   },
                 },
               },
@@ -58,14 +54,14 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       post: {
-        summary: `Create new ${key}`,
-        operationId: getOperationId({ method: 'post', model: key }),
-        tags: [key],
+        summary: `Create new ${modelName}`,
+        operationId: getOperationId({ method: 'post', model: modelName }),
+        tags: [modelName],
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${key}`,
+                $ref: `#/components/schemas/${modelName}`,
               },
             },
           },
@@ -77,7 +73,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${key}`,
+                  $ref: `#/components/schemas/${modelName}`,
                 },
               },
             },
@@ -90,12 +86,12 @@ const getModelPaths = (
     },
     [`${pathPrefix}/count`]: {
       get: {
-        summary: `Get ${key} count`,
+        summary: `Get ${modelName} count`,
         operationId: getOperationId({
-          model: key,
+          model: modelName,
           subcommand: 'count',
         }),
-        tags: [key],
+        tags: [modelName],
         parameters: getQueryParameters(),
         responses: {
           200: {
@@ -122,9 +118,9 @@ const getModelPaths = (
     },
     [`${pathPrefix}/{id}`]: {
       get: {
-        summary: `Get ${key} by id`,
-        operationId: getOperationId({ model: key, id: true }),
-        tags: [key],
+        summary: `Get ${modelName} by id`,
+        operationId: getOperationId({ model: modelName, id: true }),
+        tags: [modelName],
         parameters: getPathParameters(),
         responses: {
           200: {
@@ -132,7 +128,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${key}`,
+                  $ref: `#/components/schemas/${modelName}`,
                 },
               },
             },
@@ -143,19 +139,19 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       post: {
-        summary: `Update ${key} by id`,
+        summary: `Update ${modelName} by id`,
         operationId: getOperationId({
           method: 'post',
           id: true,
-          model: key,
+          model: modelName,
         }),
-        tags: [key],
+        tags: [modelName],
         parameters: getPathParameters(),
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${key}`,
+                $ref: `#/components/schemas/${modelName}`,
               },
             },
           },
@@ -167,7 +163,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${key}`,
+                  $ref: `#/components/schemas/${modelName}`,
                 },
               },
             },
@@ -178,19 +174,19 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       put: {
-        summary: `Update ${key} by id`,
+        summary: `Update ${modelName} by id`,
         operationId: getOperationId({
           method: 'put',
           id: true,
-          model: key,
+          model: modelName,
         }),
-        tags: [key],
+        tags: [modelName],
         parameters: getPathParameters(),
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${key}`,
+                $ref: `#/components/schemas/${modelName}`,
               },
             },
           },
@@ -202,7 +198,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${key}`,
+                  $ref: `#/components/schemas/${modelName}`,
                 },
               },
             },
@@ -213,19 +209,19 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       patch: {
-        summary: `Update ${key} by id`,
+        summary: `Update ${modelName} by id`,
         operationId: getOperationId({
           method: 'patch',
           id: true,
-          model: key,
+          model: modelName,
         }),
-        tags: [key],
+        tags: [modelName],
         parameters: getPathParameters(),
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${key}`,
+                $ref: `#/components/schemas/${modelName}`,
               },
             },
           },
@@ -237,7 +233,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${key}`,
+                  $ref: `#/components/schemas/${modelName}`,
                 },
               },
             },
@@ -248,13 +244,13 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       delete: {
-        summary: `Delete ${key} by id`,
+        summary: `Delete ${modelName} by id`,
         operationId: getOperationId({
           method: 'delete',
-          model: key,
+          model: modelName,
           id: true,
         }),
-        tags: [key],
+        tags: [modelName],
         parameters: getPathParameters(),
         responses: {
           204: {
@@ -268,13 +264,13 @@ const getModelPaths = (
     },
     [`${pathPrefix}/{id}/shallow`]: {
       get: {
-        summary: `Get ${key} by id shallow`,
+        summary: `Get ${modelName} by id shallow`,
         operationId: getOperationId({
-          model: key,
+          model: modelName,
           id: true,
           subcommand: 'shallow',
         }),
-        tags: [key],
+        tags: [modelName],
         parameters: getPathParameters(),
         responses: {
           200: {
@@ -282,7 +278,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${key}`,
+                  $ref: `#/components/schemas/${modelName}`,
                 },
               },
             },
@@ -296,9 +292,9 @@ const getModelPaths = (
   };
 };
 
-const getModelSegments = (model, options) => ({
-  schemas: getModelSchemas(model, options),
-  paths: getModelPaths(model, options),
+const getModelSegments = (input, options) => ({
+  schemas: getModelSchemas(input, options),
+  paths: getModelPaths(input, options),
 });
 
 module.exports = {

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,10 @@ const { getOperationId } = require('./operations');
 const { m2s } = require('./utils');
 
 const getModelSchemas = ({ model, options: { model: modelOptions } = {} }) => {
-  const { modelName } = model;
+  const { modelName: key } = model;
   const { title, ...rest } = m2s(model, modelOptions);
   return {
-    [modelName]: {
+    [key]: {
       type: 'object',
       ...rest,
     },
@@ -17,7 +17,7 @@ const getModelSchemas = ({ model, options: { model: modelOptions } = {} }) => {
 
 const getModelPaths = (
   {
-    model: { modelName },
+    model: { modelName: key },
     options: {
       erm: { prefix = '/api', version = '/v1' } = {},
       openapi: { paths: modelPathOverrides = {} } = {},
@@ -25,14 +25,14 @@ const getModelPaths = (
   } = {},
   { openapi: { paths: globalPathOverrides = {} } = {} } = {},
 ) => {
-  const pathPrefix = `${prefix}${version}/${modelName}`;
+  const pathPrefix = `${prefix}${version}/${key}`;
 
   return {
     [pathPrefix]: {
       get: {
-        summary: `Query ${modelName}`,
-        operationId: getOperationId({ model: modelName }),
-        tags: [modelName],
+        summary: `Query ${key}`,
+        operationId: getOperationId({ model: key }),
+        tags: [key],
         parameters: getQueryParameters(),
         responses: {
           200: {
@@ -42,7 +42,7 @@ const getModelPaths = (
                 schema: {
                   type: 'array',
                   items: {
-                    $ref: `#/components/schemas/${modelName}`,
+                    $ref: `#/components/schemas/${key}`,
                   },
                 },
               },
@@ -54,14 +54,14 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       post: {
-        summary: `Create new ${modelName}`,
-        operationId: getOperationId({ method: 'post', model: modelName }),
-        tags: [modelName],
+        summary: `Create new ${key}`,
+        operationId: getOperationId({ method: 'post', model: key }),
+        tags: [key],
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${modelName}`,
+                $ref: `#/components/schemas/${key}`,
               },
             },
           },
@@ -73,7 +73,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${modelName}`,
+                  $ref: `#/components/schemas/${key}`,
                 },
               },
             },
@@ -86,12 +86,12 @@ const getModelPaths = (
     },
     [`${pathPrefix}/count`]: {
       get: {
-        summary: `Get ${modelName} count`,
+        summary: `Get ${key} count`,
         operationId: getOperationId({
-          model: modelName,
+          model: key,
           subcommand: 'count',
         }),
-        tags: [modelName],
+        tags: [key],
         parameters: getQueryParameters(),
         responses: {
           200: {
@@ -118,9 +118,9 @@ const getModelPaths = (
     },
     [`${pathPrefix}/{id}`]: {
       get: {
-        summary: `Get ${modelName} by id`,
-        operationId: getOperationId({ model: modelName, id: true }),
-        tags: [modelName],
+        summary: `Get ${key} by id`,
+        operationId: getOperationId({ model: key, id: true }),
+        tags: [key],
         parameters: getPathParameters(),
         responses: {
           200: {
@@ -128,7 +128,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${modelName}`,
+                  $ref: `#/components/schemas/${key}`,
                 },
               },
             },
@@ -139,19 +139,19 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       post: {
-        summary: `Update ${modelName} by id`,
+        summary: `Update ${key} by id`,
         operationId: getOperationId({
           method: 'post',
           id: true,
-          model: modelName,
+          model: key,
         }),
-        tags: [modelName],
+        tags: [key],
         parameters: getPathParameters(),
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${modelName}`,
+                $ref: `#/components/schemas/${key}`,
               },
             },
           },
@@ -163,7 +163,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${modelName}`,
+                  $ref: `#/components/schemas/${key}`,
                 },
               },
             },
@@ -174,19 +174,19 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       put: {
-        summary: `Update ${modelName} by id`,
+        summary: `Update ${key} by id`,
         operationId: getOperationId({
           method: 'put',
           id: true,
-          model: modelName,
+          model: key,
         }),
-        tags: [modelName],
+        tags: [key],
         parameters: getPathParameters(),
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${modelName}`,
+                $ref: `#/components/schemas/${key}`,
               },
             },
           },
@@ -198,7 +198,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${modelName}`,
+                  $ref: `#/components/schemas/${key}`,
                 },
               },
             },
@@ -209,19 +209,19 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       patch: {
-        summary: `Update ${modelName} by id`,
+        summary: `Update ${key} by id`,
         operationId: getOperationId({
           method: 'patch',
           id: true,
-          model: modelName,
+          model: key,
         }),
-        tags: [modelName],
+        tags: [key],
         parameters: getPathParameters(),
         requestBody: {
           content: {
             'application/json': {
               schema: {
-                $ref: `#/components/schemas/${modelName}`,
+                $ref: `#/components/schemas/${key}`,
               },
             },
           },
@@ -233,7 +233,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${modelName}`,
+                  $ref: `#/components/schemas/${key}`,
                 },
               },
             },
@@ -244,13 +244,13 @@ const getModelPaths = (
         ...modelPathOverrides,
       },
       delete: {
-        summary: `Delete ${modelName} by id`,
+        summary: `Delete ${key} by id`,
         operationId: getOperationId({
           method: 'delete',
-          model: modelName,
+          model: key,
           id: true,
         }),
-        tags: [modelName],
+        tags: [key],
         parameters: getPathParameters(),
         responses: {
           204: {
@@ -264,13 +264,13 @@ const getModelPaths = (
     },
     [`${pathPrefix}/{id}/shallow`]: {
       get: {
-        summary: `Get ${modelName} by id shallow`,
+        summary: `Get ${key} by id shallow`,
         operationId: getOperationId({
-          model: modelName,
+          model: key,
           id: true,
           subcommand: 'shallow',
         }),
-        tags: [modelName],
+        tags: [key],
         parameters: getPathParameters(),
         responses: {
           200: {
@@ -278,7 +278,7 @@ const getModelPaths = (
             content: {
               'application/json': {
                 schema: {
-                  $ref: `#/components/schemas/${modelName}`,
+                  $ref: `#/components/schemas/${key}`,
                 },
               },
             },

--- a/lib/index.test.js
+++ b/lib/index.test.js
@@ -6,20 +6,18 @@ describe('lib', () => {
   describe('getModelSchemas()', () => {
     beforeEach(() => {
       _.unset(mongoose, 'models.Foo');
+      _.unset(mongoose, 'models.Bar');
     });
 
     it('should generate a schema', () => {
-      const schema = getModelSchemas([
-        'foo',
-        {
-          model: mongoose.model('Foo', {
-            name: String,
-          }),
-        },
-      ]);
+      const schema = getModelSchemas({
+        model: mongoose.model('Foo', {
+          name: String,
+        }),
+      });
 
       expect(schema).toEqual({
-        foo: {
+        Foo: {
           type: 'object',
           properties: {
             name: {
@@ -33,41 +31,103 @@ describe('lib', () => {
       });
     });
 
-    it('should include description property', () => {
-      const schema = getModelSchemas([
-        'foo',
-        {
-          model: mongoose.model('Foo', {
-            name: { type: String, required: true, description: 'baz' },
-          }),
-        },
-      ]);
+    it('should generate a schema with refs', () => {
+      const fooModel = mongoose.model('Foo', {
+        name: String,
+        bar: { type: mongoose.Schema.Types.ObjectId, ref: 'Bar' },
+        bazzes: [{ type: mongoose.Schema.Types.ObjectId, ref: 'Baz' }],
+        barr: { type: 'ObjectId', ref: 'Bar' },
+      });
+      mongoose.model('Bar', { name: String });
+      mongoose.model('Baz', { name: String });
 
-      expect(schema.foo.properties.name.description).toEqual('baz');
-    });
+      const schema = getModelSchemas({ model: fooModel });
 
-    it('should allow including custom properties', () => {
-      const schema = getModelSchemas([
-        'foo',
-        {
-          model: mongoose.model('Foo', {
-            name: { type: String, required: true, bar: 'baz' },
-          }),
-          options: {
-            model: {
-              props: ['bar'],
+      expect(schema).toEqual({
+        Foo: {
+          type: 'object',
+          properties: {
+            name: {
+              type: 'string',
+            },
+            bar: {
+              oneOf: [
+                {
+                  type: 'string',
+                },
+                {
+                  $ref: '#/components/schemas/Bar',
+                },
+              ],
+            },
+            bazzes: {
+              type: 'array',
+              items: {
+                oneOf: [
+                  {
+                    type: 'string',
+                  },
+                  {
+                    $ref: '#/components/schemas/Baz',
+                  },
+                ],
+              },
+            },
+            barr: {
+              oneOf: [
+                {
+                  type: 'string',
+                },
+                {
+                  $ref: '#/components/schemas/Bar',
+                },
+              ],
+            },
+            _id: {
+              type: 'string',
             },
           },
         },
-      ]);
+      });
+    });
 
-      expect(schema.foo.properties.name.bar).toEqual('baz');
+    it('should include description property', () => {
+      const schema = getModelSchemas({
+        model: mongoose.model('Foo', {
+          name: { type: String, required: true, description: 'baz' },
+        }),
+      });
+
+      expect(schema.Foo.properties.name.description).toEqual('baz');
+    });
+
+    it('should allow including custom properties', () => {
+      const schema = getModelSchemas({
+        model: mongoose.model('Foo', {
+          name: { type: String, required: true, bar: 'baz' },
+        }),
+        options: {
+          model: {
+            props: ['bar'],
+          },
+        },
+      });
+
+      expect(schema.Foo.properties.name.bar).toEqual('baz');
     });
   });
 
   describe('getModelPaths()', () => {
+    beforeEach(() => {
+      _.unset(mongoose, 'models.Foo');
+    });
+
     it('should add path parameters', () => {
-      const paths = getModelPaths(['foo']);
+      const paths = getModelPaths({
+        model: mongoose.model('Foo', {
+          name: { type: String, required: true, bar: 'baz' },
+        }),
+      });
       const expected = [
         {
           name: 'id',
@@ -79,31 +139,39 @@ describe('lib', () => {
         },
       ];
 
-      expect(paths['/api/v1/foo/{id}'].get.parameters).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].post.parameters).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].put.parameters).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].patch.parameters).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].delete.parameters).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].get.parameters).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].post.parameters).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].put.parameters).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].patch.parameters).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].delete.parameters).toEqual(expected);
     });
 
     it('should add tags', () => {
-      const paths = getModelPaths(['foo']);
-      const expected = ['foo'];
+      const paths = getModelPaths({
+        model: mongoose.model('Foo', {
+          name: { type: String, required: true, bar: 'baz' },
+        }),
+      });
+      const expected = ['Foo'];
 
-      expect(paths['/api/v1/foo'].get.tags).toEqual(expected);
-      expect(paths['/api/v1/foo'].post.tags).toEqual(expected);
+      expect(paths['/api/v1/Foo'].get.tags).toEqual(expected);
+      expect(paths['/api/v1/Foo'].post.tags).toEqual(expected);
 
-      expect(paths['/api/v1/foo/count'].get.tags).toEqual(expected);
+      expect(paths['/api/v1/Foo/count'].get.tags).toEqual(expected);
 
-      expect(paths['/api/v1/foo/{id}'].get.tags).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].post.tags).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].put.tags).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].patch.tags).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].delete.tags).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].get.tags).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].post.tags).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].put.tags).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].patch.tags).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].delete.tags).toEqual(expected);
     });
 
     it('should add default error', () => {
-      const paths = getModelPaths(['foo']);
+      const paths = getModelPaths({
+        model: mongoose.model('Foo', {
+          name: { type: String, required: true, bar: 'baz' },
+        }),
+      });
       const expected = {
         description: 'Unexpected Error',
         content: {
@@ -115,22 +183,22 @@ describe('lib', () => {
         },
       };
 
-      expect(paths['/api/v1/foo'].get.responses.default).toEqual(expected);
-      expect(paths['/api/v1/foo'].post.responses.default).toEqual(expected);
+      expect(paths['/api/v1/Foo'].get.responses.default).toEqual(expected);
+      expect(paths['/api/v1/Foo'].post.responses.default).toEqual(expected);
 
-      expect(paths['/api/v1/foo/count'].get.responses.default).toEqual(
+      expect(paths['/api/v1/Foo/count'].get.responses.default).toEqual(
         expected,
       );
 
-      expect(paths['/api/v1/foo/{id}'].get.responses.default).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].post.responses.default).toEqual(
+      expect(paths['/api/v1/Foo/{id}'].get.responses.default).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].post.responses.default).toEqual(
         expected,
       );
-      expect(paths['/api/v1/foo/{id}'].put.responses.default).toEqual(expected);
-      expect(paths['/api/v1/foo/{id}'].patch.responses.default).toEqual(
+      expect(paths['/api/v1/Foo/{id}'].put.responses.default).toEqual(expected);
+      expect(paths['/api/v1/Foo/{id}'].patch.responses.default).toEqual(
         expected,
       );
-      expect(paths['/api/v1/foo/{id}'].delete.responses.default).toEqual(
+      expect(paths['/api/v1/Foo/{id}'].delete.responses.default).toEqual(
         expected,
       );
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,302 @@
+// https://github.com/giddyinc/mongoose-to-swagger/blob/master/lib/index.ts
+
+const _ = require('lodash');
+const { ObjectId } = require('bson');
+
+const mapMongooseTypeToSwaggerType = (type, { ref } = {}) => {
+  if (!type) {
+    return null;
+  }
+
+  if (
+    type === Number ||
+    (_.isString(type) && type.toLowerCase() === 'number')
+  ) {
+    return 'number';
+  }
+
+  if (
+    type === String ||
+    (_.isString(type) && type.toLowerCase() === 'string')
+  ) {
+    return 'string';
+  }
+
+  if (type.schemaName === 'Mixed') {
+    return 'object';
+  }
+
+  if (type === 'ObjectId' || type === 'ObjectID') {
+    if (ref) {
+      return {
+        oneOf: [{ type: 'string' }, { $ref: `#/components/schemas/${ref}` }],
+      };
+    }
+
+    return 'string';
+  }
+
+  if (type === ObjectId) {
+    if (ref) {
+      return {
+        oneOf: [{ type: 'string' }, { $ref: `#/components/schemas/${ref}` }],
+      };
+    }
+
+    return 'string';
+  }
+
+  if (
+    type === Boolean ||
+    (_.isString(type) && type.toLowerCase() === 'boolean')
+  ) {
+    return 'boolean';
+  }
+
+  if (type === Map) {
+    return 'map';
+  }
+
+  if (type instanceof Function) {
+    // special types
+    if (type.name === 'ObjectId' || type.name === 'ObjectID') {
+      if (ref) {
+        return {
+          oneOf: [{ type: 'string' }, { $ref: `#/components/schemas/${ref}` }],
+        };
+      }
+
+      return 'string';
+    }
+
+    if (type.name === 'Date') {
+      return 'string';
+    }
+
+    if (type.name === 'Decimal128') {
+      return 'number';
+    }
+
+    return type.name.toLowerCase();
+  }
+
+  if (type.type != null) {
+    return mapMongooseTypeToSwaggerType(type.type, type);
+  }
+
+  if (type.instance) {
+    switch (type.instance) {
+      case 'Array':
+      case 'DocumentArray':
+        return 'array';
+      case 'ObjectId':
+      case 'ObjectID':
+      case 'SchemaDate':
+        return 'string';
+      case 'Mixed':
+        return 'object';
+      case 'String':
+      case 'SchemaString':
+      case 'SchemaBuffer':
+      case 'SchemaObjectId':
+        return 'string';
+
+      case 'SchemaArray':
+        return 'array';
+      case 'Boolean':
+      case 'SchemaBoolean':
+        return 'boolean';
+      case 'Number':
+      case 'Decimal128':
+      case 'SchemaNumber':
+        return 'number';
+      default:
+    }
+  }
+
+  if (Array.isArray(type)) {
+    return 'array';
+  }
+
+  if (type.$schemaType) {
+    return mapMongooseTypeToSwaggerType(type.$schemaType.tree);
+  }
+
+  if (type.getters && Array.isArray(type.getters) && type.path != null) {
+    return null; // virtuals should not render
+  }
+
+  return 'object';
+};
+
+const defaultSupportedMetaProps = ['enum', 'required', 'description'];
+
+const mapSchemaTypeToFieldSchema = ({
+  key = null, // null = array field
+  value,
+  props,
+}) => {
+  const swaggerType = mapMongooseTypeToSwaggerType(value);
+  const meta = {};
+
+  for (const metaProp of props) {
+    if (value && value[metaProp] != null) {
+      meta[metaProp] = value[metaProp];
+    }
+  }
+
+  if (value === Date || value.type === Date) {
+    meta.format = 'date-time';
+  } else if (swaggerType === 'array') {
+    const arraySchema = Array.isArray(value) ? value[0] : value.type[0];
+    const items = mapSchemaTypeToFieldSchema({
+      value: arraySchema || {},
+      props,
+    });
+    meta.items = items;
+  } else if (swaggerType === 'object') {
+    let fields = [];
+    if (value && value.constructor && value.constructor.name === 'Schema') {
+      fields = getFieldsFromMongooseSchema(value, { props });
+    } else {
+      const subSchema = value.type ? value.type : value;
+      if (subSchema.obj && Object.keys(subSchema.obj).length > 0) {
+        fields = getFieldsFromMongooseSchema(
+          { tree: subSchema.tree ? subSchema.tree : subSchema },
+          { props },
+        );
+      } else if (subSchema.schemaName !== 'Mixed') {
+        fields = getFieldsFromMongooseSchema(
+          { tree: subSchema.tree ? subSchema.tree : subSchema },
+          { props },
+        );
+      }
+    }
+
+    const properties = {};
+
+    for (const field of fields.filter(f => f.type != null)) {
+      properties[field.field] = field;
+      delete field.field;
+    }
+
+    meta.properties = properties;
+  } else if (swaggerType === 'map') {
+    const subSchema = mapSchemaTypeToFieldSchema({
+      value: value.of || {},
+      props,
+    });
+    // swagger defines map as an `object` type
+    meta.type = 'object';
+    // with `additionalProperties` instead of `properties`
+    meta.additionalProperties = subSchema;
+  }
+
+  const result = {
+    ...(_.has(swaggerType, 'oneOf') ? swaggerType : { type: swaggerType }),
+    ...meta,
+  };
+
+  if (key) {
+    result.field = key;
+  }
+
+  return result;
+};
+
+const getFieldsFromMongooseSchema = (schema, options) => {
+  const { props } = options;
+  const tree = schema.tree;
+  const keys = Object.keys(schema.tree);
+  const fields = [];
+
+  // loop over the tree of mongoose schema types
+  // and return an array of swagger fields
+  for (const key of keys.filter(x => x != 'id')) {
+    const value = tree[key];
+
+    // swagger object
+    const field = mapSchemaTypeToFieldSchema({ key, value, props });
+    const required = [];
+
+    if (field.type === 'object') {
+      const { field: propName } = field;
+      const fieldProperties = field.properties || field.additionalProperties;
+      for (const f of Object.values(fieldProperties)) {
+        if (f.required && propName != null) {
+          required.push(propName);
+          delete f.required;
+        }
+      }
+    }
+
+    if (field.type === 'array' && field.items.type === 'object') {
+      field.items.required = [];
+      for (const key in field.items.properties) {
+        const val = field.items.properties[key];
+        if (val.required) {
+          field.items.required.push(key);
+          delete val.required;
+        }
+      }
+    }
+
+    fields.push(field);
+  }
+
+  return fields;
+};
+
+/**
+ * Entry Point
+ * @param Model Mongoose Model Instance
+ */
+function m2s(Model, options = {}) {
+  let { props = [], omitFields = [] } = options;
+  props = [...defaultSupportedMetaProps, ...props];
+
+  let omitted = new Set(['__v', ...omitFields]);
+  const removeOmitted = swaggerFieldSchema => {
+    return (
+      (swaggerFieldSchema.type != null || swaggerFieldSchema.oneOf !== null) &&
+      !omitted.has(swaggerFieldSchema.field)
+    );
+  };
+
+  // console.log('swaggering', Model.modelName);
+  const schema = Model.schema;
+
+  // get an array of deeply hydrated fields
+  const fields = getFieldsFromMongooseSchema(schema, { props });
+
+  // root is always an object
+  const obj = {
+    title: Model.modelName,
+    required: [],
+    properties: {},
+  };
+
+  // key deeply hydrated fields by field name
+  for (const field of fields.filter(removeOmitted)) {
+    const { field: fieldName } = field;
+    delete field.field;
+    obj.properties[fieldName] = field;
+    if (field.required && fieldName != null) {
+      obj.required.push(fieldName);
+      delete field.required;
+    }
+  }
+
+  if (!obj.required || !obj.required.length) {
+    delete obj.required;
+  }
+
+  return obj;
+}
+
+m2s.adjustType = mapMongooseTypeToSwaggerType;
+m2s.getFieldsFromMongooseSchema = getFieldsFromMongooseSchema;
+
+module.exports = {
+  m2s,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "erm2openapi",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1274,6 +1274,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1347,10 +1352,21 @@
       }
     },
     "bson": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
-      "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
-      "dev": true
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+      "integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
     },
     "buffer-from": {
       "version": "1.1.1",
@@ -3145,6 +3161,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -4340,6 +4361,14 @@
         "require_optional": "^1.0.1",
         "safe-buffer": "^5.1.2",
         "saslprep": "^1.0.0"
+      },
+      "dependencies": {
+        "bson": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+          "dev": true
+        }
       }
     },
     "mongoose": {
@@ -4362,6 +4391,12 @@
         "sliced": "1.0.1"
       },
       "dependencies": {
+        "bson": {
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
+          "dev": true
+        },
         "safe-buffer": {
           "version": "5.2.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -4375,11 +4410,6 @@
       "resolved": "https://registry.npmjs.org/mongoose-legacy-pluralize/-/mongoose-legacy-pluralize-1.0.2.tgz",
       "integrity": "sha512-Yo/7qQU4/EyIS8YDFSeenIvXxZN+ld7YdV9LqFVQJzTLye8unujAWPZ4NWKfFA+RNjh+wvTWKY9Z3E5XM6ZZiQ==",
       "dev": true
-    },
-    "mongoose-to-swagger": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mongoose-to-swagger/-/mongoose-to-swagger-1.2.0.tgz",
-      "integrity": "sha512-Wr6jJq4GO1sPH7OxsSb1oXYjj+rt4kQKyV/OeOP9xojxHGXO6xrmkOES++v/iIST/NhwP3rTzbkp2moRJO4o1g=="
     },
     "mpath": {
       "version": "0.8.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "erm2openapi",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Create OpenAPI documentation from Mongoose schemas for express-restify-mongoose servers.",
   "main": "index.js",
   "scripts": {
@@ -42,7 +42,7 @@
     "prettier": "^2.2.1"
   },
   "dependencies": {
-    "lodash": "^4.17.21",
-    "mongoose-to-swagger": "^1.2.0"
+    "bson": "^4.3.0",
+    "lodash": "^4.17.21"
   }
 }

--- a/test/fixtures/api-docs.json
+++ b/test/fixtures/api-docs.json
@@ -15,7 +15,9 @@
       "get": {
         "summary": "Query story",
         "operationId": "getStory",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "parameters": [
           {
             "name": "sort",
@@ -106,7 +108,9 @@
       "post": {
         "summary": "Create new story",
         "operationId": "createStory",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -155,7 +159,9 @@
       "get": {
         "summary": "Get story count",
         "operationId": "getStoryCount",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "parameters": [
           {
             "name": "sort",
@@ -219,7 +225,9 @@
                       "type": "number"
                     }
                   },
-                  "required": ["count"]
+                  "required": [
+                    "count"
+                  ]
                 }
               }
             }
@@ -251,7 +259,9 @@
       "get": {
         "summary": "Get story by id",
         "operationId": "getStoryById",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -308,7 +318,9 @@
       "post": {
         "summary": "Update story by id",
         "operationId": "updateStory",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -375,7 +387,9 @@
       "put": {
         "summary": "Update story by id",
         "operationId": "replaceStory",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -442,7 +456,9 @@
       "patch": {
         "summary": "Update story by id",
         "operationId": "patchStory",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -509,7 +525,9 @@
       "delete": {
         "summary": "Delete story by id",
         "operationId": "deleteStory",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -551,7 +569,9 @@
       "get": {
         "summary": "Get story by id shallow",
         "operationId": "getStoryByIdShallow",
-        "tags": ["story"],
+        "tags": [
+          "story"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -600,7 +620,9 @@
       "get": {
         "summary": "Query person",
         "operationId": "getPerson",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "parameters": [
           {
             "name": "sort",
@@ -691,7 +713,9 @@
       "post": {
         "summary": "Create new person",
         "operationId": "createPerson",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -740,7 +764,9 @@
       "get": {
         "summary": "Get person count",
         "operationId": "getPersonCount",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "parameters": [
           {
             "name": "sort",
@@ -804,7 +830,9 @@
                       "type": "number"
                     }
                   },
-                  "required": ["count"]
+                  "required": [
+                    "count"
+                  ]
                 }
               }
             }
@@ -836,7 +864,9 @@
       "get": {
         "summary": "Get person by id",
         "operationId": "getPersonById",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -893,7 +923,9 @@
       "post": {
         "summary": "Update person by id",
         "operationId": "updatePerson",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -960,7 +992,9 @@
       "put": {
         "summary": "Update person by id",
         "operationId": "replacePerson",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1027,7 +1061,9 @@
       "patch": {
         "summary": "Update person by id",
         "operationId": "patchPerson",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1094,7 +1130,9 @@
       "delete": {
         "summary": "Delete person by id",
         "operationId": "deletePerson",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1136,7 +1174,9 @@
       "get": {
         "summary": "Get person by id shallow",
         "operationId": "getPersonByIdShallow",
-        "tags": ["person"],
+        "tags": [
+          "person"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -1185,7 +1225,10 @@
   "components": {
     "schemas": {
       "error": {
-        "required": ["name", "message"],
+        "required": [
+          "name",
+          "message"
+        ],
         "type": "object",
         "properties": {
           "name": {
@@ -1198,10 +1241,19 @@
       },
       "story": {
         "type": "object",
-        "required": ["title"],
+        "required": [
+          "title"
+        ],
         "properties": {
           "author": {
-            "type": "string"
+            "oneOf": [
+              {
+                "type": "string"
+              },
+              {
+                "$ref": "#/components/schemas/person"
+              }
+            ]
           },
           "title": {
             "type": "string"
@@ -1209,7 +1261,14 @@
           "fans": {
             "type": "array",
             "items": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/person"
+                }
+              ]
             }
           },
           "_id": {
@@ -1219,7 +1278,9 @@
       },
       "person": {
         "type": "object",
-        "required": ["name"],
+        "required": [
+          "name"
+        ],
         "properties": {
           "name": {
             "type": "string"
@@ -1230,7 +1291,14 @@
           "stories": {
             "type": "array",
             "items": {
-              "type": "string"
+              "oneOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "$ref": "#/components/schemas/story"
+                }
+              ]
             }
           },
           "_id": {

--- a/test/fixtures/api-docs.json
+++ b/test/fixtures/api-docs.json
@@ -15,9 +15,7 @@
       "get": {
         "summary": "Query story",
         "operationId": "getStory",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "parameters": [
           {
             "name": "sort",
@@ -108,9 +106,7 @@
       "post": {
         "summary": "Create new story",
         "operationId": "createStory",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "requestBody": {
           "content": {
             "application/json": {
@@ -159,9 +155,7 @@
       "get": {
         "summary": "Get story count",
         "operationId": "getStoryCount",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "parameters": [
           {
             "name": "sort",
@@ -225,9 +219,7 @@
                       "type": "number"
                     }
                   },
-                  "required": [
-                    "count"
-                  ]
+                  "required": ["count"]
                 }
               }
             }
@@ -259,9 +251,7 @@
       "get": {
         "summary": "Get story by id",
         "operationId": "getStoryById",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "parameters": [
           {
             "name": "id",
@@ -318,9 +308,7 @@
       "post": {
         "summary": "Update story by id",
         "operationId": "updateStory",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "parameters": [
           {
             "name": "id",
@@ -387,9 +375,7 @@
       "put": {
         "summary": "Update story by id",
         "operationId": "replaceStory",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "parameters": [
           {
             "name": "id",
@@ -456,9 +442,7 @@
       "patch": {
         "summary": "Update story by id",
         "operationId": "patchStory",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "parameters": [
           {
             "name": "id",
@@ -525,9 +509,7 @@
       "delete": {
         "summary": "Delete story by id",
         "operationId": "deleteStory",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "parameters": [
           {
             "name": "id",
@@ -569,9 +551,7 @@
       "get": {
         "summary": "Get story by id shallow",
         "operationId": "getStoryByIdShallow",
-        "tags": [
-          "story"
-        ],
+        "tags": ["story"],
         "parameters": [
           {
             "name": "id",
@@ -620,9 +600,7 @@
       "get": {
         "summary": "Query person",
         "operationId": "getPerson",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "parameters": [
           {
             "name": "sort",
@@ -713,9 +691,7 @@
       "post": {
         "summary": "Create new person",
         "operationId": "createPerson",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "requestBody": {
           "content": {
             "application/json": {
@@ -764,9 +740,7 @@
       "get": {
         "summary": "Get person count",
         "operationId": "getPersonCount",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "parameters": [
           {
             "name": "sort",
@@ -830,9 +804,7 @@
                       "type": "number"
                     }
                   },
-                  "required": [
-                    "count"
-                  ]
+                  "required": ["count"]
                 }
               }
             }
@@ -864,9 +836,7 @@
       "get": {
         "summary": "Get person by id",
         "operationId": "getPersonById",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "parameters": [
           {
             "name": "id",
@@ -923,9 +893,7 @@
       "post": {
         "summary": "Update person by id",
         "operationId": "updatePerson",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "parameters": [
           {
             "name": "id",
@@ -992,9 +960,7 @@
       "put": {
         "summary": "Update person by id",
         "operationId": "replacePerson",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "parameters": [
           {
             "name": "id",
@@ -1061,9 +1027,7 @@
       "patch": {
         "summary": "Update person by id",
         "operationId": "patchPerson",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "parameters": [
           {
             "name": "id",
@@ -1130,9 +1094,7 @@
       "delete": {
         "summary": "Delete person by id",
         "operationId": "deletePerson",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "parameters": [
           {
             "name": "id",
@@ -1174,9 +1136,7 @@
       "get": {
         "summary": "Get person by id shallow",
         "operationId": "getPersonByIdShallow",
-        "tags": [
-          "person"
-        ],
+        "tags": ["person"],
         "parameters": [
           {
             "name": "id",
@@ -1225,10 +1185,7 @@
   "components": {
     "schemas": {
       "error": {
-        "required": [
-          "name",
-          "message"
-        ],
+        "required": ["name", "message"],
         "type": "object",
         "properties": {
           "name": {
@@ -1241,9 +1198,7 @@
       },
       "story": {
         "type": "object",
-        "required": [
-          "title"
-        ],
+        "required": ["title"],
         "properties": {
           "author": {
             "oneOf": [
@@ -1278,9 +1233,7 @@
       },
       "person": {
         "type": "object",
-        "required": [
-          "name"
-        ],
+        "required": ["name"],
         "properties": {
           "name": {
             "type": "string"


### PR DESCRIPTION
Update logic to support populate statements. Component schemas specify refs using oneOf to support
both un-populated string or string[] as well as $ref or $ref[].